### PR TITLE
Add forgotten connection context disposal for SASL

### DIFF
--- a/memcached/internal/mc_sasl.c
+++ b/memcached/internal/mc_sasl.c
@@ -272,3 +272,8 @@ int memcached_sasl_step(struct memcached_connection *con,
 	return -1;
 }
 
+void memcached_sasl_connection_destroy(struct memcached_connection *con) {
+	struct sasl_ctx *ctx = con->sasl_ctx;
+	sasl_dispose(&ctx->sasl_conn);
+}
+

--- a/memcached/internal/mc_sasl.h
+++ b/memcached/internal/mc_sasl.h
@@ -24,5 +24,6 @@ int memcached_sasl_auth(struct memcached_connection *con, const char *mech,
 int memcached_sasl_step(struct memcached_connection *con,
 			const char *challenge, size_t challenge_len,
 			const char **out, size_t *out_len);
+void memcached_sasl_connection_destroy(struct memcached_connection *con);
 
 #endif /* MC_SASL_H_INCLUDED */

--- a/memcached/internal/memcached.c
+++ b/memcached/internal/memcached.c
@@ -240,6 +240,7 @@ memcached_handler(struct memcached_service *p, int fd)
 	/* close connection and reflect it in stats */
 	con.cfg->stat.curr_conns--;
 	iobuf_delete(con.in, con.out);
+	memcached_sasl_connection_destroy(&con);
 	free((void *)con.sasl_ctx);
 	const box_error_t *err = box_error_last();
 	if (err)


### PR DESCRIPTION
Should close tarantool/tarantool#3392