### PR TITLE
Error on expiration fiber start while under tarantoolctl

### DIFF
--- a/memcached/init.lua
+++ b/memcached/init.lua
@@ -8,7 +8,9 @@ local log    = require('log')
 
 local fmt = string.format
 
-ffi.load(package.searchpath('memcached.internal', package.cpath), true)
+local internal_so_path = package.search('memcached.internal')
+assert(internal_so_path, "Failed to find memcached/internal.so library")
+ffi.load(internal_so_path, true)
 
 ffi.cdef[[
 struct memcached_stat {

--- a/memcached/internal/expiration.c
+++ b/memcached/internal/expiration.c
@@ -108,6 +108,7 @@ memcached_expire_start(struct memcached_service *p)
 	struct fiber *expire_fiber = NULL;
 	char name[128];
 	snprintf(name, 128, "__mc_%s_expire", p->name);
+	box_error_clear();
 	expire_fiber = fiber_new(name, memcached_expire_loop);
 	const box_error_t *err = box_error_last();
 	if (err) {


### PR DESCRIPTION
Checking box.error.last() is the only way to determine that fiber start was failed.
Also another way to find `internal.so`

Checked on 1.10.

Closes #44.