### PR TITLE
Fix memory allocate during request processing

### DIFF
--- a/memcached/init.lua
+++ b/memcached/init.lua
@@ -314,8 +314,8 @@ local memcached_methods = {
         return self
     end,
     info = function (self)
-        stats = C.memcached_get_stat(self.service)
-        retval = {}
+        local stats = C.memcached_get_stat(self.service)
+        local retval = {}
         for k, v in pairs(stat_table) do
             retval[v] = stats[0][v]
         end

--- a/memcached/internal/memcached.h
+++ b/memcached/internal/memcached.h
@@ -11,6 +11,7 @@
 
 
 #include <small/obuf.h>
+#include <small/region.h>
 #include "constants.h"
 
 struct memcached_connection;
@@ -142,6 +143,8 @@ struct memcached_connection {
 		memcached_loop_func_t     process_request;
 		memcached_error_func_t    process_error;
 	} cb; /* protocol specific callbacks */
+	/* A garbage collected memory pool used in request processing. */
+	struct region gc;
 };
 
 struct memcached_stat *

--- a/memcached/internal/memcached_layer.c
+++ b/memcached/internal/memcached_layer.c
@@ -71,7 +71,7 @@ memcached_tuple_set(struct memcached_connection *con,
 		       mp_sizeof_str  (vlen)   +
 		       mp_sizeof_uint (cas)    +
 		       mp_sizeof_uint (flags);
-	char *begin  = (char *)box_txn_alloc(len);
+	char *begin = (char *)region_alloc(&con->gc, len);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(len, "tuple");
 		return -1;
@@ -95,7 +95,7 @@ memcached_tuple_get(struct memcached_connection *con,
 	/* Create key for getting previous tuple from space */
 	uint32_t len = mp_sizeof_array(1) +
 		       mp_sizeof_str  (key_len);
-	char *begin  = (char *)box_txn_alloc(len);
+	char *begin = (char *)region_alloc(&con->gc, len);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(len, "key");
 		return -1;

--- a/memcached/internal/proto_bin.c
+++ b/memcached/internal/proto_bin.c
@@ -324,7 +324,7 @@ memcached_bin_process_delete(struct memcached_connection *con)
 	con->cfg->stat.cmd_delete++;
 	uint32_t len = mp_sizeof_array(1) +
 		       mp_sizeof_str  (b->key_len);
-	char *begin = (char *)box_txn_alloc(len);
+	char *begin = (char *)region_alloc(&con->gc, len);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(len, "key");
 		return -1;
@@ -682,7 +682,7 @@ memcached_bin_process_pend(struct memcached_connection *con)
 	mp_next(&pos); /* skip cas */
 	flags            = mp_decode_uint(&pos);
 
-	char *begin = (char *)box_txn_alloc(b->val_len + vlen);
+	char *begin = (char *)region_alloc(&con->gc, b->val_len + vlen);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(b->val_len + vlen, "value");
 		return -1;

--- a/memcached/internal/proto_txt.c
+++ b/memcached/internal/proto_txt.c
@@ -288,7 +288,7 @@ memcached_txt_process_pend(struct memcached_connection *con)
 	mp_next(&pos); /* skip cas */
 	flags            = mp_decode_uint(&pos);
 
-	char *begin = (char *)box_txn_alloc(data_len + vlen);
+	char *begin = (char *)region_alloc(&con->gc, data_len + vlen);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(data_len + vlen, "value");
 		return -1;
@@ -322,7 +322,7 @@ memcached_txt_process_delete(struct memcached_connection *con)
 	con->cfg->stat.cmd_delete++;
 	uint32_t len = mp_sizeof_array(1) +
 		       mp_sizeof_str  (key_len);
-	char *begin = (char *)box_txn_alloc(len);
+	char *begin = (char *)region_alloc(&con->gc, len);
 	if (begin == NULL) {
 		memcached_error_ENOMEM(len, "key");
 		return -1;

--- a/test/text/multiversioning.result
+++ b/test/text/multiversioning.result
@@ -50,36 +50,3 @@ STAT reclaimed 0
 STAT auth_cmds 0
 STAT auth_errors 0
 END
-box.stat()
----
-- DELETE:
-    total: 0
-    rps: 0
-  SELECT:
-    total: 7
-    rps: 0
-  INSERT:
-    total: 2
-    rps: 0
-  EVAL:
-    total: 0
-    rps: 0
-  CALL:
-    total: 0
-    rps: 0
-  REPLACE:
-    total: 1
-    rps: 0
-  UPSERT:
-    total: 0
-    rps: 0
-  AUTH:
-    total: 0
-    rps: 0
-  ERROR:
-    total: 0
-    rps: 0
-  UPDATE:
-    total: 1
-    rps: 0
-...

--- a/test/text/multiversioning.test.py
+++ b/test/text/multiversioning.test.py
@@ -48,6 +48,5 @@ server.cleanup()
 server.start()
 
 mc_client('stats\r\n')
-admin('box.stat()')
 
 sys.path = saved_path


### PR DESCRIPTION
Before introducing a txn memory region box_txn_alloc() allocates memory using the fiber.gc region and can be used without box_txn_begin(). Now the similar trick doesn't work (a transaction must be started).
To allocate memory on region without start a transaction, the region was added to struct memcached_connection.

Fixes #53