### PR TITLE
ci: add verify on different tarantool versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,14 @@ env:
     global:
       - PRODUCT=tarantool-memcached
     matrix:
-      - TARGET=test
+      - TARGET=test TARANTOOL_VERSION=1.10
+      - TARGET=test TARANTOOL_VERSION=2.1
+      - TARGET=test TARANTOOL_VERSION=2.2
+      - TARGET=test TARANTOOL_VERSION=2.3
+      - TARGET=test TARANTOOL_VERSION=2.4
+      - TARGET=test TARANTOOL_VERSION=2.5
+      - TARGET=test TARANTOOL_VERSION=2.6
+      - TARGET=test TARANTOOL_VERSION=2.7
       - OS=el DIST=6
       - OS=el DIST=7
       - OS=el DIST=8

--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,10 @@
 
 set -eu  # Strict shell, w/o print commands (set -x), w/o -o pipefail
 
-curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.deb.sh | sudo bash
-sudo apt-get install -y tarantool tarantool-dev libevent-dev libsasl2-dev --force-yes
+TARANTOOL_VERSION=${TARANTOOL_VERSION:-1.10}
+
+curl -sL https://tarantool.io/installer.sh | sudo VER=$TARANTOOL_VERSION bash
+sudo apt-get install -y libevent-dev libsasl2-dev --force-yes
 pip install --user python-daemon PyYAML six==1.9.0 msgpack-python gevent==1.1.2
 TARANTOOL_DIR=/usr/include cmake . -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
Now, Travis CI will run tests for memcached module
using Tarantool versions 1.10, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7

Added few jobs to .travis.yml for this feature.
Updated way to enable tarantool repo to
`curl -L https://tarantool.io/installer.sh | sudo VER=2.5 bash`
in test.sh and made TARANTOOL_VERSION variable in test.sh

Closed #58 