### PR TITLE
build: require tarantool-1.10+ in Debian packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: database
 Maintainer: Eugene Blikh <bigbes@tarantool.org>
 Build-Depends: debhelper (>= 9), cdbs,
                cmake (>= 2.8),
-               tarantool-dev (>= 1.6.8.0),
+               tarantool-dev (>= 1.10.0),
                libsmall-dev,
 #              libmsgpuck-dev,
                libsasl2-dev
@@ -15,7 +15,7 @@ Vcs-Browser: https://github.com/tarantool/memcached
 
 Package: tarantool-memcached
 Architecture: i386 amd64 armhf arm64
-Depends: tarantool (>= 1.6.8.0), ${shlibs:Depends}, ${misc:Depends}
+Depends: tarantool (>= 1.10.0), ${shlibs:Depends}, ${misc:Depends}
 Pre-Depends: ${misc:Pre-Depends}
 Description: Memcached protocol emulation for Tarantool
  This package provides a Memcached protocol emulation for Tarantool.


### PR DESCRIPTION
Follows up commit 1f6d7b03eae7555a0c3914888f5f526bc62ead31 ('Update RPM
spec file to match the rockspec').

Since tarantool-memcached-1.0.1 we support tarantool-1.10 or newer (see
the release notes [1]). This change reflects this fact in the Debian
packages for the module.

[1]: https://github.com/tarantool/memcached/releases/tag/1.0.1

@ChangeLog (for #68 and this PR both): Updated the RPM and Deb packages
to reflect the fact that the module supports tarantool since 1.10.