### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs/memcached-1.0.0-1.rockspec
+++ b/rockspecs/memcached-1.0.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'memcached'
 version = '1.0.0-1'
 
 source  = {
-    url = 'git://github.com/tarantool/memcached.git';
+    url = 'git+https://github.com/tarantool/memcached.git';
     tag = '1.0.0';
 }
 

--- a/rockspecs/memcached-1.0.1-1.rockspec
+++ b/rockspecs/memcached-1.0.1-1.rockspec
@@ -2,7 +2,7 @@ package = 'memcached'
 version = '1.0.1-1'
 
 source  = {
-    url = 'git://github.com/tarantool/memcached.git';
+    url = 'git+https://github.com/tarantool/memcached.git';
     tag = '1.0.1';
 }
 

--- a/rockspecs/memcached-scm-1.rockspec
+++ b/rockspecs/memcached-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'memcached'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/memcached.git';
+    url    = 'git+https://github.com/tarantool/memcached.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587