### PR TITLE
github-ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -1,0 +1,46 @@
+name: reusable_testing
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone the memcached module
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/memcached
+          # Enable recursive submodules checkout as test-run git module is used
+          # for running tests.
+          submodules: recursive
+
+      - name: Download the tarantool build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Install tarantool
+        # Now we're lucky: all dependencies are already installed. Check package
+        # dependencies when migrating to other OS version.
+        run: sudo dpkg -i tarantool_*.deb tarantool-common_*.deb tarantool-dev_*.deb
+
+      - name: Setup python2 for tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install build requirements
+        run: sudo apt-get -y install libsasl2-dev
+
+      - name: Install test requirements
+        run: pip install -r test-run/requirements.txt
+
+      - run: cmake . && make
+      - run: make test-memcached

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -29,7 +29,7 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
 
       - name: Install build requirements
-        run: sudo apt-get -y install libsasl2-dev
+        run: sudo apt-get -y install libsasl2-dev libevent-dev
 
       - run: cmake .
 
@@ -42,3 +42,4 @@ jobs:
         run: pip install -r test-run/requirements.txt
 
       - run: make test-memcached
+      - run: make test-memcached-capable


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
memcached module with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
'integration.yml' workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
memcached.

Part of tarantool/tarantool#6563
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056

Related to tarantool/tarantool#6613