### PR TITLE
ci: use python 3 in reusable_testing.yml workflow

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -38,10 +38,10 @@ jobs:
           TNT_VERSION=$(tarantool --version | grep -e '^Tarantool')
           echo "TNT_VERSION=$TNT_VERSION" >> $GITHUB_ENV
 
-      - name: Setup python2 for tests
+      - name: Setup python3 for tests
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.7
 
       - name: Install build requirements
         run: sudo apt-get -y install libsasl2-dev


### PR DESCRIPTION
The memcached tests have migrated to Python 3 recently in scope of #82.
But reusable_testing.yml workflow wasn't updated and tests started to
fail. This patch fixes the issue.