### PR TITLE
Bump small library version

### DIFF
--- a/memcached/internal/memcached.c
+++ b/memcached/internal/memcached.c
@@ -34,8 +34,8 @@
 #include <stdbool.h>
 
 #include <tarantool/module.h>
-#include <small/ibuf.h>
-#include <small/obuf.h>
+#include <include/small/ibuf.h>
+#include <include/small/obuf.h>
 
 #include "memcached.h"
 #include "memcached_layer.h"

--- a/memcached/internal/memcached.h
+++ b/memcached/internal/memcached.h
@@ -10,8 +10,8 @@
  */
 
 
-#include <small/obuf.h>
-#include <small/region.h>
+#include <include/small/obuf.h>
+#include <include/small/region.h>
 #include "constants.h"
 
 struct memcached_connection;

--- a/memcached/internal/memcached_layer.c
+++ b/memcached/internal/memcached_layer.c
@@ -11,7 +11,7 @@
 #include <tarantool/module.h>
 
 #include <msgpuck.h>
-#include <small/obuf.h>
+#include <include/small/obuf.h>
 
 #include "error.h"
 #include "memcached.h"

--- a/memcached/internal/network.c
+++ b/memcached/internal/network.c
@@ -10,9 +10,9 @@
 #include <fcntl.h>
 
 #include <tarantool/module.h>
-#include <small/mempool.h>
-#include <small/ibuf.h>
-#include <small/obuf.h>
+#include <include/small/mempool.h>
+#include <include/small/ibuf.h>
+#include <include/small/obuf.h>
 
 #include "memcached.h"
 #include "constants.h"

--- a/memcached/internal/network.h
+++ b/memcached/internal/network.h
@@ -3,7 +3,7 @@
 
 #define TIMEOUT_INFINITY 365*86400*100.0
 
-#include <small/ibuf.h>
+#include <include/small/ibuf.h>
 
 size_t
 mnet_writev(int fd, struct iovec *iov, int iovcnt, size_t size_hint);

--- a/memcached/internal/proto_bin.c
+++ b/memcached/internal/proto_bin.c
@@ -15,8 +15,8 @@
 #include "memcached_layer.h"
 #include "mc_sasl.h"
 
-#include <small/ibuf.h>
-#include <small/obuf.h>
+#include <include/small/ibuf.h>
+#include <include/small/obuf.h>
 
 static inline int
 memcached_bin_write(struct memcached_connection *con, uint16_t err,

--- a/memcached/internal/proto_txt.c
+++ b/memcached/internal/proto_txt.c
@@ -4,8 +4,8 @@
 
 #include <tarantool/module.h>
 #include <msgpuck.h>
-#include <small/ibuf.h>
-#include <small/obuf.h>
+#include <include/small/ibuf.h>
+#include <include/small/obuf.h>
 
 #include "memcached.h"
 #include "constants.h"


### PR DESCRIPTION
Current version of Small library made on Jan 2020 - commit "Revert "Free
all slabs on region reset" (3df5050171d040bfe5717b4bddf57da3b312ffe4).
Since Jan 2020 there were added many changes to Small library that
includes also regression bugfixes, see [1].

1. https://github.com/tarantool/small/compare/3df5050171d040bfe5717b4bddf57da3b312ffe4..055458f1d45948f7d768e2499496926dcf78b26f

Closes #92