### PR TITLE
memcached: allow to pass port as a number to memcached.create()

### DIFF
--- a/memcached/init.lua
+++ b/memcached/init.lua
@@ -347,7 +347,7 @@ local function memcached_init(name, uri, opts)
     local instance = {}
     instance.opts = conf
     instance.name = name
-    instance.uri  = uri
+    instance.uri  = tostring(uri)
     instance.space_name = opts.space_name or '__mc_' .. instance.name
     if box.space[instance.space_name] == nil then
         local storage = startswith(conf.storage, 'mem') and 'memtx' or 'vinyl'


### PR DESCRIPTION
For creating memcached instance module requires instance name, URI and
table with options. URI is a string with hostname and port number
separated by colon. Instead URI user can pass a port as a number, but
memcached doesn't expect it and fails with exception. Patch fixes it by
adding conversion of uri to a string.

Fixes #107