### PR TITLE
ibuf: don't clash with tarantool's ibuf_*() symbols

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,18 @@
+# Hacking
+
+Here we collect arcane knowledge, which may be useful for developers of the
+module.
+
+## memcached_ibuf
+
+`third_party/memcached_ibuf.[ch]` is the copy of ibuf from the small library
+with renaming of the functions. The motivation is to avoid possible name clash
+between tarantool's symbols and the module's symbols. See [1] and [2] for
+details.
+
+We can remove it, when we'll dedice to drop support of tarantool versions
+affected by [1] or will find another way to overcome the name clash (see [3]).
+
+[1]: https://github.com/tarantool/tarantool/issues/6873
+[2]: https://github.com/tarantool/memcached/issues/59#issuecomment-1081106140
+[3]: https://github.com/tarantool/memcached/issues/92#issuecomment-1081128938

--- a/README.md
+++ b/README.md
@@ -190,3 +190,8 @@ For custom configuration file path, please, use `SASL_CONF_PATH` environment var
 ## Caution
 
 This rock is in early beta.
+
+## Hacking
+
+We're collecting information for the module developers in the
+[HACKING.md](HACKING.md) file.

--- a/memcached/CMakeLists.txt
+++ b/memcached/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(internalso SHARED
         "internal/expiration.c"
         "internal/memcached.c"
         "internal/mc_sasl.c"
+        "${CMAKE_SOURCE_DIR}/third_party/memcached_ibuf.c"
 )
 
 target_link_libraries(internalso msgpuck)

--- a/memcached/internal/memcached.c
+++ b/memcached/internal/memcached.c
@@ -34,11 +34,11 @@
 #include <stdbool.h>
 
 #include <tarantool/module.h>
-#include <small/ibuf.h>
 #include <small/obuf.h>
 
 #include "alloc.h"
 #include "memcached.h"
+#include "memcached_ibuf.h"
 #include "memcached_layer.h"
 #include "error.h"
 #include "network.h"

--- a/memcached/internal/network.c
+++ b/memcached/internal/network.c
@@ -49,7 +49,8 @@ ibuf_new()
 {
 	void *ibuf = mempool_alloc(&ibuf_pool);
 	if (ibuf == NULL) return NULL;
-	ibuf_create((struct ibuf *)ibuf, memcached_slab_cache(), iobuf_readahead);
+	memcached_ibuf_create((struct ibuf *)ibuf, memcached_slab_cache(),
+			      iobuf_readahead);
 	return ibuf;
 }
 
@@ -65,7 +66,7 @@ obuf_new()
 void
 iobuf_delete(struct ibuf *ibuf, struct obuf *obuf)
 {
-	ibuf_destroy(ibuf);
+	memcached_ibuf_destroy(ibuf);
 	obuf_destroy(obuf);
 	mempool_free(&ibuf_pool, ibuf);
 	mempool_free(&obuf_pool, obuf);
@@ -148,10 +149,11 @@ mnet_read_ahead(int fd, void *buf, size_t bufsz, size_t sz)
 size_t
 mnet_read_ibuf(int fd, struct ibuf *buf, size_t sz)
 {
-	if (ibuf_reserve(buf, sz) == NULL) {
+	if (memcached_ibuf_reserve(buf, sz) == NULL) {
 		return -1;
 	}
-	ssize_t n = mnet_read_ahead(fd, buf->wpos, ibuf_unused(buf), sz);
+	ssize_t n = mnet_read_ahead(fd, buf->wpos, memcached_ibuf_unused(buf),
+				    sz);
 	buf->wpos += n;
 	return n;
 }

--- a/memcached/internal/network.c
+++ b/memcached/internal/network.c
@@ -11,11 +11,11 @@
 
 #include <tarantool/module.h>
 #include <small/mempool.h>
-#include <small/ibuf.h>
 #include <small/obuf.h>
 
 #include "alloc.h"
 #include "memcached.h"
+#include "memcached_ibuf.h"
 #include "constants.h"
 #include "network.h"
 

--- a/memcached/internal/network.h
+++ b/memcached/internal/network.h
@@ -3,7 +3,7 @@
 
 #define TIMEOUT_INFINITY 365*86400*100.0
 
-#include <small/ibuf.h>
+#include "memcached_ibuf.h"
 
 size_t
 mnet_writev(int fd, struct iovec *iov, int iovcnt, size_t size_hint);

--- a/memcached/internal/proto_bin.c
+++ b/memcached/internal/proto_bin.c
@@ -15,7 +15,7 @@
 #include "memcached_layer.h"
 #include "mc_sasl.h"
 
-#include <small/ibuf.h>
+#include "memcached_ibuf.h"
 #include <small/obuf.h>
 
 static inline int

--- a/memcached/internal/proto_txt.c
+++ b/memcached/internal/proto_txt.c
@@ -4,10 +4,10 @@
 
 #include <tarantool/module.h>
 #include <msgpuck.h>
-#include <small/ibuf.h>
 #include <small/obuf.h>
 
 #include "memcached.h"
+#include "memcached_ibuf.h"
 #include "constants.h"
 #include "memcached_layer.h"
 #include "error.h"

--- a/third_party/memcached_ibuf.c
+++ b/third_party/memcached_ibuf.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2010-2016, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "memcached_ibuf.h"
+#include <string.h>
+#include <small/slab_cache.h>
+
+/** Initialize an input buffer. */
+void
+ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc, size_t start_capacity)
+{
+	ibuf->slabc = slabc;
+	ibuf->buf = ibuf->rpos = ibuf->wpos = ibuf->end = NULL;
+	ibuf->start_capacity = start_capacity;
+	/* Don't allocate the buffer yet. */
+}
+
+void
+ibuf_destroy(struct ibuf *ibuf)
+{
+	if (ibuf->buf) {
+		struct slab *slab = slab_from_data(ibuf->buf);
+		slab_put(ibuf->slabc, slab);
+	 }
+}
+
+/** Free memory allocated by this buffer */
+void
+ibuf_reinit(struct ibuf *ibuf)
+{
+	struct slab_cache *slabc = ibuf->slabc;
+	size_t start_capacity = ibuf->start_capacity;
+	ibuf_destroy(ibuf);
+	ibuf_create(ibuf, slabc, start_capacity);
+}
+
+/**
+ * Ensure the buffer has sufficient capacity
+ * to store size bytes, and return pointer to
+ * the beginning.
+ */
+void *
+ibuf_reserve_slow(struct ibuf *ibuf, size_t size)
+{
+	assert(ibuf->wpos + size > ibuf->end);
+	size_t used = ibuf_used(ibuf);
+	size_t capacity = ibuf_capacity(ibuf);
+	/*
+	 * Check if we have enough space in the
+	 * current buffer. In this case de-fragment it
+	 * by moving existing data to the beginning.
+	 * Otherwise, get a bigger buffer.
+	 */
+	if (size + used <= capacity) {
+		memmove(ibuf->buf, ibuf->rpos, used);
+	} else {
+		/* Use iobuf_readahead as allocation factor. */
+		size_t new_capacity = capacity * 2;
+		if (new_capacity < ibuf->start_capacity)
+			new_capacity = ibuf->start_capacity;
+
+		while (new_capacity < used + size)
+			new_capacity *= 2;
+
+		struct slab *slab = slab_get(ibuf->slabc, new_capacity);
+		if (slab == NULL)
+			return NULL;
+		char *ptr = (char *) slab_data(slab);
+		memcpy(ptr, ibuf->rpos, used);
+		if (ibuf->buf)
+			slab_put(ibuf->slabc, slab_from_data(ibuf->buf));
+		ibuf->buf = ptr;
+		ibuf->end = ibuf->buf + slab_capacity(slab);
+	}
+	ibuf->rpos = ibuf->buf;
+	ibuf->wpos = ibuf->rpos + used;
+	return ibuf->wpos;
+}
+

--- a/third_party/memcached_ibuf.c
+++ b/third_party/memcached_ibuf.c
@@ -34,7 +34,8 @@
 
 /** Initialize an input buffer. */
 void
-ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc, size_t start_capacity)
+memcached_ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc,
+		      size_t start_capacity)
 {
 	ibuf->slabc = slabc;
 	ibuf->buf = ibuf->rpos = ibuf->wpos = ibuf->end = NULL;
@@ -43,7 +44,7 @@ ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc, size_t start_capacity)
 }
 
 void
-ibuf_destroy(struct ibuf *ibuf)
+memcached_ibuf_destroy(struct ibuf *ibuf)
 {
 	if (ibuf->buf) {
 		struct slab *slab = slab_from_data(ibuf->buf);
@@ -53,12 +54,12 @@ ibuf_destroy(struct ibuf *ibuf)
 
 /** Free memory allocated by this buffer */
 void
-ibuf_reinit(struct ibuf *ibuf)
+memcached_ibuf_reinit(struct ibuf *ibuf)
 {
 	struct slab_cache *slabc = ibuf->slabc;
 	size_t start_capacity = ibuf->start_capacity;
-	ibuf_destroy(ibuf);
-	ibuf_create(ibuf, slabc, start_capacity);
+	memcached_ibuf_destroy(ibuf);
+	memcached_ibuf_create(ibuf, slabc, start_capacity);
 }
 
 /**
@@ -67,11 +68,11 @@ ibuf_reinit(struct ibuf *ibuf)
  * the beginning.
  */
 void *
-ibuf_reserve_slow(struct ibuf *ibuf, size_t size)
+memcached_ibuf_reserve_slow(struct ibuf *ibuf, size_t size)
 {
 	assert(ibuf->wpos + size > ibuf->end);
-	size_t used = ibuf_used(ibuf);
-	size_t capacity = ibuf_capacity(ibuf);
+	size_t used = memcached_ibuf_used(ibuf);
+	size_t capacity = memcached_ibuf_capacity(ibuf);
 	/*
 	 * Check if we have enough space in the
 	 * current buffer. In this case de-fragment it

--- a/third_party/memcached_ibuf.h
+++ b/third_party/memcached_ibuf.h
@@ -1,0 +1,206 @@
+#ifndef TARANTOOL_SMALL_IBUF_H_INCLUDED
+#define TARANTOOL_SMALL_IBUF_H_INCLUDED
+/*
+ * Copyright 2010-2016, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <stddef.h>
+#include <assert.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** @module Input buffer. */
+
+struct slab_cache;
+
+/*
+ * Continuous piece of memory to store input.
+ * Allocated in factors of 'start_capacity'.
+ * Maintains position of the data "to be processed".
+ *
+ * Typical use case:
+ *
+ * struct ibuf *in;
+ * coio_bread(coio, in, request_len);
+ * if (ibuf_size(in) >= request_len) {
+ *	process_request(in->rpos, request_len);
+ *	in->rpos += request_len;
+ * }
+ */
+struct ibuf
+{
+	struct slab_cache *slabc;
+	char *buf;
+	/** Start of input. */
+	char *rpos;
+	/** End of useful input */
+	char *wpos;
+	/** End of buffer. */
+	char *end;
+	size_t start_capacity;
+};
+
+void
+ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc, size_t start_capacity);
+
+void
+ibuf_destroy(struct ibuf *ibuf);
+
+void
+ibuf_reinit(struct ibuf *ibuf);
+
+/** How much data is read and is not parsed yet. */
+static inline size_t
+ibuf_used(struct ibuf *ibuf)
+{
+	assert(ibuf->wpos >= ibuf->rpos);
+	return ibuf->wpos - ibuf->rpos;
+}
+
+/** How much data can we fit beyond buf->wpos */
+static inline size_t
+ibuf_unused(struct ibuf *ibuf)
+{
+	assert(ibuf->wpos <= ibuf->end);
+	return ibuf->end - ibuf->wpos;
+}
+
+/** How much memory is allocated */
+static inline size_t
+ibuf_capacity(struct ibuf *ibuf)
+{
+	return ibuf->end - ibuf->buf;
+}
+
+/**
+ * Integer value of the position in the buffer - stable
+ * in case of realloc.
+ */
+static inline size_t
+ibuf_pos(struct ibuf *ibuf)
+{
+	assert(ibuf->buf <= ibuf->rpos);
+	return ibuf->rpos - ibuf->buf;
+}
+
+/** Forget all cached input. */
+static inline void
+ibuf_reset(struct ibuf *ibuf)
+{
+	ibuf->rpos = ibuf->wpos = ibuf->buf;
+}
+
+void *
+ibuf_reserve_slow(struct ibuf *ibuf, size_t size);
+
+static inline void *
+ibuf_reserve(struct ibuf *ibuf, size_t size)
+{
+	if (ibuf->wpos + size <= ibuf->end)
+		return ibuf->wpos;
+	return ibuf_reserve_slow(ibuf, size);
+}
+
+static inline void *
+ibuf_alloc(struct ibuf *ibuf, size_t size)
+{
+	void *ptr;
+	if (ibuf->wpos + size <= ibuf->end)
+		ptr = ibuf->wpos;
+	else {
+		ptr = ibuf_reserve_slow(ibuf, size);
+		if (ptr == NULL)
+			return NULL;
+	}
+	ibuf->wpos += size;
+	return ptr;
+}
+
+static inline void *
+ibuf_reserve_cb(void *ctx, size_t *size)
+{
+	struct ibuf *buf = (struct ibuf *) ctx;
+	void *p = ibuf_reserve(buf, *size ? *size : buf->start_capacity);
+	*size = ibuf_unused(buf);
+	return p;
+}
+
+static inline void *
+ibuf_alloc_cb(void *ctx, size_t size)
+{
+	return ibuf_alloc((struct ibuf *) ctx, size);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+
+#include "exception.h"
+
+/** Reserve space for sz bytes in the input buffer. */
+static inline void *
+ibuf_reserve_xc(struct ibuf *ibuf, size_t size)
+{
+	void *ptr = ibuf_reserve(ibuf, size);
+	if (ptr == NULL)
+		tnt_raise(OutOfMemory, size, "ibuf", "reserve");
+	return ptr;
+}
+
+static inline void *
+ibuf_alloc_xc(struct ibuf *ibuf, size_t size)
+{
+	void *ptr = ibuf_alloc(ibuf, size);
+	if (ptr == NULL)
+		tnt_raise(OutOfMemory, size, "ibuf", "alloc");
+	return ptr;
+}
+
+static inline void *
+ibuf_reserve_xc_cb(void *ctx, size_t *size)
+{
+	void *ptr = ibuf_reserve_cb(ctx, size);
+	if (ptr == NULL)
+		tnt_raise(OutOfMemory, *size, "ibuf", "reserve");
+	return ptr;
+}
+
+static inline void *
+ibuf_alloc_xc_cb(void *ctx, size_t size)
+{
+	void *ptr = ibuf_alloc_cb(ctx, size);
+	if (ptr == NULL)
+		tnt_raise(OutOfMemory, size, "ibuf", "alloc");
+	return ptr;
+}
+
+#endif /* defined(__cplusplus) */
+
+#endif /* TARANTOOL_SMALL_IBUF_H_INCLUDED */

--- a/third_party/memcached_ibuf.h
+++ b/third_party/memcached_ibuf.h
@@ -161,46 +161,6 @@ ibuf_alloc_cb(void *ctx, size_t size)
 
 #if defined(__cplusplus)
 } /* extern "C" */
-
-#include "exception.h"
-
-/** Reserve space for sz bytes in the input buffer. */
-static inline void *
-ibuf_reserve_xc(struct ibuf *ibuf, size_t size)
-{
-	void *ptr = ibuf_reserve(ibuf, size);
-	if (ptr == NULL)
-		tnt_raise(OutOfMemory, size, "ibuf", "reserve");
-	return ptr;
-}
-
-static inline void *
-ibuf_alloc_xc(struct ibuf *ibuf, size_t size)
-{
-	void *ptr = ibuf_alloc(ibuf, size);
-	if (ptr == NULL)
-		tnt_raise(OutOfMemory, size, "ibuf", "alloc");
-	return ptr;
-}
-
-static inline void *
-ibuf_reserve_xc_cb(void *ctx, size_t *size)
-{
-	void *ptr = ibuf_reserve_cb(ctx, size);
-	if (ptr == NULL)
-		tnt_raise(OutOfMemory, *size, "ibuf", "reserve");
-	return ptr;
-}
-
-static inline void *
-ibuf_alloc_xc_cb(void *ctx, size_t size)
-{
-	void *ptr = ibuf_alloc_cb(ctx, size);
-	if (ptr == NULL)
-		tnt_raise(OutOfMemory, size, "ibuf", "alloc");
-	return ptr;
-}
-
 #endif /* defined(__cplusplus) */
 
 #endif /* TARANTOOL_SMALL_IBUF_H_INCLUDED */

--- a/third_party/memcached_ibuf.h
+++ b/third_party/memcached_ibuf.h
@@ -1,5 +1,5 @@
-#ifndef TARANTOOL_SMALL_IBUF_H_INCLUDED
-#define TARANTOOL_SMALL_IBUF_H_INCLUDED
+#ifndef MEMCACHED_IBUF_H_INCLUDED
+#define MEMCACHED_IBUF_H_INCLUDED
 /*
  * Copyright 2010-2016, Tarantool AUTHORS, please see AUTHORS file.
  *
@@ -69,17 +69,18 @@ struct ibuf
 };
 
 void
-ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc, size_t start_capacity);
+memcached_ibuf_create(struct ibuf *ibuf, struct slab_cache *slabc,
+		      size_t start_capacity);
 
 void
-ibuf_destroy(struct ibuf *ibuf);
+memcached_ibuf_destroy(struct ibuf *ibuf);
 
 void
-ibuf_reinit(struct ibuf *ibuf);
+memcached_ibuf_reinit(struct ibuf *ibuf);
 
 /** How much data is read and is not parsed yet. */
 static inline size_t
-ibuf_used(struct ibuf *ibuf)
+memcached_ibuf_used(struct ibuf *ibuf)
 {
 	assert(ibuf->wpos >= ibuf->rpos);
 	return ibuf->wpos - ibuf->rpos;
@@ -87,7 +88,7 @@ ibuf_used(struct ibuf *ibuf)
 
 /** How much data can we fit beyond buf->wpos */
 static inline size_t
-ibuf_unused(struct ibuf *ibuf)
+memcached_ibuf_unused(struct ibuf *ibuf)
 {
 	assert(ibuf->wpos <= ibuf->end);
 	return ibuf->end - ibuf->wpos;
@@ -95,7 +96,7 @@ ibuf_unused(struct ibuf *ibuf)
 
 /** How much memory is allocated */
 static inline size_t
-ibuf_capacity(struct ibuf *ibuf)
+memcached_ibuf_capacity(struct ibuf *ibuf)
 {
 	return ibuf->end - ibuf->buf;
 }
@@ -105,7 +106,7 @@ ibuf_capacity(struct ibuf *ibuf)
  * in case of realloc.
  */
 static inline size_t
-ibuf_pos(struct ibuf *ibuf)
+memcached_ibuf_pos(struct ibuf *ibuf)
 {
 	assert(ibuf->buf <= ibuf->rpos);
 	return ibuf->rpos - ibuf->buf;
@@ -113,30 +114,30 @@ ibuf_pos(struct ibuf *ibuf)
 
 /** Forget all cached input. */
 static inline void
-ibuf_reset(struct ibuf *ibuf)
+memcached_ibuf_reset(struct ibuf *ibuf)
 {
 	ibuf->rpos = ibuf->wpos = ibuf->buf;
 }
 
 void *
-ibuf_reserve_slow(struct ibuf *ibuf, size_t size);
+memcached_ibuf_reserve_slow(struct ibuf *ibuf, size_t size);
 
 static inline void *
-ibuf_reserve(struct ibuf *ibuf, size_t size)
+memcached_ibuf_reserve(struct ibuf *ibuf, size_t size)
 {
 	if (ibuf->wpos + size <= ibuf->end)
 		return ibuf->wpos;
-	return ibuf_reserve_slow(ibuf, size);
+	return memcached_ibuf_reserve_slow(ibuf, size);
 }
 
 static inline void *
-ibuf_alloc(struct ibuf *ibuf, size_t size)
+memcached_ibuf_alloc(struct ibuf *ibuf, size_t size)
 {
 	void *ptr;
 	if (ibuf->wpos + size <= ibuf->end)
 		ptr = ibuf->wpos;
 	else {
-		ptr = ibuf_reserve_slow(ibuf, size);
+		ptr = memcached_ibuf_reserve_slow(ibuf, size);
 		if (ptr == NULL)
 			return NULL;
 	}
@@ -145,22 +146,23 @@ ibuf_alloc(struct ibuf *ibuf, size_t size)
 }
 
 static inline void *
-ibuf_reserve_cb(void *ctx, size_t *size)
+memcached_ibuf_reserve_cb(void *ctx, size_t *size)
 {
 	struct ibuf *buf = (struct ibuf *) ctx;
-	void *p = ibuf_reserve(buf, *size ? *size : buf->start_capacity);
-	*size = ibuf_unused(buf);
+	void *p = memcached_ibuf_reserve(
+		buf, *size ? *size : buf->start_capacity);
+	*size = memcached_ibuf_unused(buf);
 	return p;
 }
 
 static inline void *
-ibuf_alloc_cb(void *ctx, size_t size)
+memcached_ibuf_alloc_cb(void *ctx, size_t size)
 {
-	return ibuf_alloc((struct ibuf *) ctx, size);
+	return memcached_ibuf_alloc((struct ibuf *) ctx, size);
 }
 
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */
 
-#endif /* TARANTOOL_SMALL_IBUF_H_INCLUDED */
+#endif /* MEMCACHED_IBUF_H_INCLUDED */


### PR DESCRIPTION
Copy `ibuf.c` and `ibuf.h` from small into the module's code and rename the functions to `memcached_ibuf_*()`.

See https://github.com/tarantool/tarantool/issues/6873 for the root problem and https://github.com/tarantool/memcached/issues/59#issuecomment-1081106140 for analysis.

`ibuf_*()` symbols may clash with the same named symbols in tarantool, so it worth to rename them to avoid effects of different binary layouts: assertion fails and memory corruptions.

It is the last known problem from #59. All others are confirmed as safe to ignore if we'll keep current libsmall version in the module (see the issue).

More details can be found in the commit messages.

Fixes #59