### PR TITLE
Fix the curl command print

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -74,7 +74,7 @@ jobs:
           # to print a "curl" command to see what's going on.
           CURL_CMD_ECHO="curl -LfsS \
             -X PUT ${RWS_URL_PART}/${OS}/${DIST} \
-            -u *** \
+            -u '***' \
             -F product=${PRODUCT_NAME}"
 
           for f in $(ls -I '*build*' -I '*.changes' ./build); do


### PR DESCRIPTION
"echo *" can function as "ls". The shell will expand the asterisk to whatever is in that directory. Therefore, it is necessary to escape this characters.