### PR TITLE
ci: bump test-run

### DIFF
--- a/test/binary/binary-boundary.test.py
+++ b/test/binary/binary-boundary.test.py
@@ -8,11 +8,11 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
 from internal.compat import string_types
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 def iequal(left, right, level = 1):
     if (left != right):

--- a/test/binary/binary-expire.test.py
+++ b/test/binary/binary-expire.test.py
@@ -8,9 +8,9 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 def iequal(left, right, level = 1):
     if (left != right):

--- a/test/binary/binary-gh-73.test.py
+++ b/test/binary/binary-gh-73.test.py
@@ -6,9 +6,9 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 batch_count = 20 # Default batch_count value used in memcached.
 

--- a/test/binary/binary-toobig.test.py
+++ b/test/binary/binary-toobig.test.py
@@ -7,9 +7,9 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 def iequal(left, right, level = 1):
     if (left != right):

--- a/test/binary/binary.lua
+++ b/test/binary/binary.lua
@@ -7,8 +7,11 @@ box.cfg{
 
 package.cpath = './?.so;' .. package.cpath
 
+-- The current version of test-run returns port zero in the LISTEN variable.
+-- Since memcache has not yet implemented an API for receiving a real listen
+-- port, it will have to be hardcoded.
 require('memcached').create('memcached',
-    os.getenv('LISTEN'):match(':(.*)'), {
+    "20509", {
         expire_full_scan_time = 1,
 })
 

--- a/test/binary/binary.test.py
+++ b/test/binary/binary.test.py
@@ -7,9 +7,9 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 def iequal(left, right, level = 1):
     if (left != right):

--- a/test/capable/capable-binary.test.py
+++ b/test/capable/capable-binary.test.py
@@ -10,15 +10,15 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
 from internal.compat import bytes_to_str
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 mc.flush()
 
 cmd = shlex.split('capable/memcapable -b -p %s -h %s -v' %
-        (iproto.py_con.port, '127.0.0.1'))
+        (CONNECT_PORT, '127.0.0.1'))
 
 task = Popen(cmd, stdout=PIPE, stderr=STDOUT)
 

--- a/test/capable/capable-text.test.py
+++ b/test/capable/capable-text.test.py
@@ -10,15 +10,15 @@ saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
 from internal.memcached_connection import MemcachedBinaryConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
 from internal.compat import bytes_to_str
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 mc.flush()
 
 cmd = shlex.split('capable/memcapable -a -p %s -h %s -v' %
-        (iproto.py_con.port, '127.0.0.1'))
+        (CONNECT_PORT, '127.0.0.1'))
 
 task = Popen(cmd, stdout=PIPE, stderr=STDOUT)
 

--- a/test/capable/capable.lua
+++ b/test/capable/capable.lua
@@ -7,9 +7,12 @@ box.cfg{
 
 package.cpath = './?.so;' .. package.cpath
 
+-- The current version of test-run returns port zero in the LISTEN variable.
+-- Since memcache has not yet implemented an API for receiving a real listen
+-- port, it will have to be hardcoded.
 require('memcached').create(
     'memcached',
-    os.getenv('LISTEN'):match(':(.*)')
+    '20509'
 )
 
 require('console').listen(os.getenv('ADMIN'))

--- a/test/internal/memcached_connection.py
+++ b/test/internal/memcached_connection.py
@@ -61,6 +61,11 @@ COMMANDS = {
     'sasl_step'  : [0x22, Struct(HEADER + ''),    0,  None, 0   ],
 }
 
+# The current version of test-run returns port zero in the LISTEN variable.
+# Since memcache has not yet implemented an API for receiving a real listen
+# port, it will have to be hardcoded.
+CONNECT_PORT = "20509"
+
 def is_indecrq(cmd):
     if cmd in (COMMANDS['incr'][0], COMMANDS['decr'][0], COMMANDS['incrq'][0],
             COMMANDS['decrq'][0]):

--- a/test/sasl/binary-sasl.test.py
+++ b/test/sasl/binary-sasl.test.py
@@ -8,9 +8,9 @@ sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))
 
 from internal.memcached_connection import MemcachedBinaryConnection
 from internal.memcached_connection import MemcachedTextConnection
-from internal.memcached_connection import STATUS, COMMANDS
+from internal.memcached_connection import STATUS, COMMANDS, CONNECT_PORT
 
-mc = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+mc = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
 
 def iequal(left, right, level = 1):
     if (left != right):
@@ -59,22 +59,22 @@ def delete(key, when):
 print("""#---------------------------# sasl tests #--------------------------#""")
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     res = mc1.set('x', 'somevalue')
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     res = mc1.delete('x', 'somevalue')
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     res = mc1.set('x', 'somevalue')
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     res = mc1.flush()
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
@@ -117,7 +117,7 @@ if True:
     empty('x')
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     secret = '%c%s%c%s' % (0, 'testuser', 0, 'wrongpass')
     res = mc1.sasl_start('PLAIN', secret)
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
@@ -126,12 +126,12 @@ if True:
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
 if True:
-    mc1 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc1 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     secret = '%c%s%c%s' % (0, 'testuser', 0, 'wrongpass')
     res = mc1.sasl_start('PLAIN', secret)
     iequal(res[0]['status'], STATUS['AUTH_ERROR'])
 
-    mc2 = MemcachedBinaryConnection("127.0.0.1", iproto.py_con.port)
+    mc2 = MemcachedBinaryConnection("127.0.0.1", CONNECT_PORT)
     secret = '%c%s%c%s' % (0, 'testuser', 0, 'testpass')
     res = mc2.sasl_start('PLAIN', secret)
     iequal(res[0]['status'], 0)

--- a/test/text/binary-get.test.py
+++ b/test/text/binary-get.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 blobs_list = [ "mooo\0", "mumble\0\0\0\0\r\rblarg", "\0", "\r" ]
 

--- a/test/text/bogus-commands.test.py
+++ b/test/text/bogus-commands.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 mc_client("boguscommand slkdsldkfjsd\r\n")
 

--- a/test/text/cas.test.py
+++ b/test/text/cas.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 mc_client("cas bad blah 0 0 0\r\n")
 mc_client("cas bad 0 blah 0 0\r\n")
@@ -73,7 +72,7 @@ else:
     print("fail: foo1_cas == foo2_cas")
 
 memcached1 = mc_client
-memcached2 = MemcachedTextConnection('localhost', port)
+memcached2 = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 print("""# gets foo from memcached1 - should success """)
 result = memcached1("gets foo1\r\n", silent = True)

--- a/test/text/expirations.test.py
+++ b/test/text/expirations.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 master_id = server.get_param('server')['id']
 

--- a/test/text/flags.test.py
+++ b/test/text/flags.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 flags_list = [0x0, 0x7b, 0xffff]
 

--- a/test/text/flush-all.test.py
+++ b/test/text/flush-all.test.py
@@ -8,10 +8,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 ###################################
 def get_memcached_len(serv):

--- a/test/text/getset.test.py
+++ b/test/text/getset.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 mc_client("flush_all\r\n", silent = True)
 

--- a/test/text/incrdecr.test.py
+++ b/test/text/incrdecr.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 print("""# incr/decr big value """)
 mc_client("set bug21 0 0 19\r\n9223372036854775807\r\n")

--- a/test/text/multiversioning.test.py
+++ b/test/text/multiversioning.test.py
@@ -7,17 +7,16 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 buf_size = 256 * 1024
 buf = "0123456789abcdef" * int(buf_size / 16)
 buf_upper = buf.upper()
 
 memcached1 = mc_client
-memcached2 = MemcachedTextConnection('localhost', port)
+memcached2 = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 print("""# Store big in lower case via first memcached client """)
 print("set big 0 0 %d\r\n<big-value-lower-case>" % buf_size)

--- a/test/text/noreply.test.py
+++ b/test/text/noreply.test.py
@@ -7,10 +7,9 @@ import traceback
 saved_path = sys.path[:]
 sys.path.append(os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda:0))))
 
-from internal.memcached_connection import MemcachedTextConnection
+from internal.memcached_connection import MemcachedTextConnection, CONNECT_PORT
 
-port = int(iproto.uri.split(':')[1])
-mc_client = MemcachedTextConnection('localhost', port)
+mc_client = MemcachedTextConnection('localhost', CONNECT_PORT)
 
 print("""# Test that commands can take 'noreply' parameter. """)
 mc_client("flush_all noreply\r\n")

--- a/test/text/text.lua
+++ b/test/text/text.lua
@@ -7,8 +7,11 @@ box.cfg{
 
 package.cpath = './?.so;' .. package.cpath
 
+-- The current version of test-run returns port zero in the LISTEN variable.
+-- Since memcache has not yet implemented an API for receiving a real listen
+-- port, it will have to be hardcoded.
 require('memcached').create('memcached',
-    os.getenv('LISTEN'):match(':(.*)'), {
+    "20509", {
         expire_full_scan_time = 1
 })
 


### PR DESCRIPTION
In the near future we plan to test Tarantool installed from a DEB/RPM package. Since 3.0.0-alpha1 release Tarantool packages don't have the tarantoolctl utility inside.

tarantoolctl was ebmed to the test-run project inself. The submodule has been updated to the latest version.

Part of tarantool/tarantool#9443