### PR TITLE
memcached: make cancellable

### DIFF
--- a/memcached/internal/network.c
+++ b/memcached/internal/network.c
@@ -143,6 +143,8 @@ mnet_read_ahead(int fd, void *buf, size_t bufsz, size_t sz)
 			return total;
 		}
 		coio_wait(fd, COIO_READ, TIMEOUT_INFINITY);
+		if (fiber_is_cancelled())
+			return total;
 	}
 }
 


### PR DESCRIPTION
We are going to finish all client (non-system) fibers in the process of Tarantool shutdown. First we cancel them and then wait for their finishing. So if the client fibers are not finished Tarantool shutdown is never finished too.

Currently memcached service fiber can not be finished and we got hang on integration testing of PR [1]. Let's fix it.

[1] PR with client fibers finishing on shutdown.
https://github.com/tarantool/tarantool/pull/9604