### PR TITLE
ci: add fedora 34 platform to packaging

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -20,6 +20,7 @@ jobs:
           - { os: 'debian', dist: 'bullseye' }
           - { os: 'el', dist: '7' }
           - { os: 'el', dist: '8' }
+          - { os: 'fedora', dist: '34' }
           - { os: 'fedora', dist: '35' }
           - { os: 'fedora', dist: '36' }
           - { os: 'ubuntu', dist: 'xenial' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Build of packages for Fedora 34 platform.
+
+### Changed
+
+### Fixed
+
 ## [1.1.1] - 2022-04-11
 
 ### Fixed


### PR DESCRIPTION
Fedora 34 needs to be supported and wasn't included to the platform list, but `packpack/packpack` supports it.

After the patch this platform has been included.

Part of #128