### PR TITLE
ci: add almalinux platform to packaging

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          - { os: 'almalinux', dist: '8'}
+          - { os: 'almalinux', dist: '9'}
           - { os: 'debian', dist: 'stretch' }
           - { os: 'debian', dist: 'buster' }
           - { os: 'debian', dist: 'bullseye' }

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -2,4 +2,21 @@
 
 set -exu  # Strict shell (w/o -o pipefail)
 
-curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
+os=""
+dist=""
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    os="$ID"
+    dist="$VERSION_ID"
+fi
+
+# The installer script is ending with unexpected error of unsupported OS for
+# "Almalinux 9". Here we fix this by overriding the cenos-release file so that
+# the enviroment settings work correctly.
+if [[ "$os" == "almalinux" && "$dist" == 9* ]]; then
+    sudo sh -c "echo 8 > /etc/centos-release"
+    curl -LsSf https://tarantool.io/release/3/installer.sh | sudo bash
+else
+    # We need to execute the 1.10 script due to it works for other platforms.
+    curl -LsSf https://tarantool.io/release/1.10/installer.sh | sudo bash
+fi


### PR DESCRIPTION
Almalinux 8, 9 needs to be supported and wasn't included to the platform list, but `packpack/packpack` supports it.

After the patch this platform has been included.

Closes #128