### PR TITLE
ci: bump ubuntu version 

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,17 +9,22 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Tarantool
-      uses: tarantool/setup-tarantool@v1
+      uses: tarantool/setup-tarantool@v3
       with:
-        tarantool-version: '2.8'
+        tarantool-version: '3.3'
 
     - name: Setup luacheck
-      run: tarantoolctl rocks install luacheck 0.25.0
+      run: |
+        sudo apt update
+        sudo apt install -y curl
+        curl -L https://tarantool.io/release/3/installer.sh | bash
+        sudo apt install -y tt
+        tt rocks install luacheck 0.25.0
 
     - run: cmake -S . -B build
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -17,18 +17,15 @@ jobs:
         platform:
           - { os: 'almalinux', dist: '8'}
           - { os: 'almalinux', dist: '9'}
-          - { os: 'debian', dist: 'stretch' }
-          - { os: 'debian', dist: 'buster' }
           - { os: 'debian', dist: 'bullseye' }
-          - { os: 'el', dist: '7' }
+          - { os: 'debian', dist: 'bookworm' }
           - { os: 'el', dist: '8' }
-          - { os: 'fedora', dist: '34' }
           - { os: 'fedora', dist: '35' }
           - { os: 'fedora', dist: '36' }
-          - { os: 'ubuntu', dist: 'xenial' }
           - { os: 'ubuntu', dist: 'bionic' }
           - { os: 'ubuntu', dist: 'focal' }
           - { os: 'ubuntu', dist: 'jammy' }
+          - { os: 'ubuntu', dist: 'noble' }
 
     env:
       OS: ${{ matrix.platform.os }}
@@ -36,13 +33,13 @@ jobs:
 
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Clone the packpack tool
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: packpack/packpack
           path: packpack

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   publish-rockspec-scm-1:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -18,9 +18,9 @@ jobs:
 
   publish-rockspec-tag:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
@@ -48,10 +48,15 @@ jobs:
       # LuaJIT's FFI and tarantool specific features are okay.
       #
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
-          tarantool-version: '2.10'
-      - run: tarantoolctl rocks pack memcached-${{ env.TAG }}-1.rockspec
+          tarantool-version: '3.3'
+      - run: |
+          sudo apt update
+          sudo apt install -y curl
+          curl -L https://tarantool.io/release/3/installer.sh | bash
+          sudo apt install -y tt
+          tt rocks pack memcached-${{ env.TAG }}-1.rockspec
 
       # Upload .rockspec and .src.rock.
       - uses: tarantool/rocks.tarantool.org/github-action@master

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the memcached module
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -11,12 +11,12 @@ jobs:
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        tarantool-version: ['1.10', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '2.8', '2.x-latest']
+        tarantool-version: ['2.11', '3.3']
       fail-fast: false
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/memcached
           # Enable recursive submodules checkout as test-run git module is used
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup Tarantool (version is not equal to latest 2.x)
         if: matrix.tarantool-version != '2.x-latest'
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool-version }}
 
@@ -36,14 +36,14 @@ jobs:
           sudo apt install -y tarantool tarantool-dev
 
       - name: Install build requirements
-        run: sudo apt-get -y install libsasl2-dev libevent-dev
+        run: sudo apt-get -y install libsasl2-dev libevent-dev libpcre3-dev
 
       - run: cmake .
 
       - name: Setup Python 3 for tests
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install test requirements
         run: pip install -r test-run/requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...3.31 FATAL_ERROR)
 
 project(memcached C)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
+
+# Fix problem with old third_party dependencies
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-set -exu  # Strict shell (w/o -o pipefail)
+set -e -o pipefail
 
-# At the time of adding the changes, tarantool 1.10 is absent in the
-# repositories Ubuntu impish and jammy.
-if [[ $DIST == "impish" ]] || [[ $DIST == "jammy" ]]; then
-  curl -LsSf https://www.tarantool.io/release/2/installer.sh | sudo bash
-else
-  curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
-fi
+curl -LsSf https://www.tarantool.io/release/2/installer.sh | sudo bash

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -17,6 +17,6 @@ if [[ "$os" == "almalinux" && "$dist" == 9* ]]; then
     sudo sh -c "echo 8 > /etc/centos-release"
     curl -LsSf https://tarantool.io/release/3/installer.sh | sudo bash
 else
-    # We need to execute the 1.10 script due to it works for other platforms.
-    curl -LsSf https://tarantool.io/release/1.10/installer.sh | sudo bash
+    # We need to execute the 2 script due to it works for other platforms.
+    curl -LsSf https://tarantool.io/release/2/installer.sh | sudo bash
 fi


### PR DESCRIPTION
Bump actions to use ubuntu-24.04 for fixing the following GitHub
warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

This commit adds CMake policy to prevent warnings from
old third_party dependencies, bumps libmemcached third_party library
to support build on Ubuntu 24.04.

Part of #TNTP-1918
Closes https://github.com/tarantool/memcached/issues/115